### PR TITLE
Downgrade NodeJS to 16.x 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '18.x'
+          node-version: '16.x'
 
       - name: Install dependencies
         run: yarn

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
     "discord-rpc": "^4.0.1",
     "electron-prompt": "^1.6.0",
     "electron-squirrel-startup": "^1.0.0",
-    "update-electron-app": "^2.0.1"
+    "update-electron-app": "^2.0.1",
+		"es5-ext": "<=0.10.53"
   },
   "devDependencies": {
     "@electron-forge/cli": "^6.0.0-beta.54",


### PR DESCRIPTION
and downgrade es5-ext to <=0.10.53 so it doesn't get marked as a virus